### PR TITLE
Add precip type to daily forecast

### DIFF
--- a/app/decorators/forecast_decorator.rb
+++ b/app/decorators/forecast_decorator.rb
@@ -35,6 +35,7 @@ class ForecastDecorator < SimpleDelegator
         day: time_abbr(day[:time], :day),
         icon: day[:icon],
         precip_probability: convert_pct(day[:precipProbability]),
+        precip_type: day[:precipType],
         temp_high: day[:temperatureHigh],
         temp_low: day[:temperatureLow]
       }

--- a/spec/requests/api/v1/forecast_spec.rb
+++ b/spec/requests/api/v1/forecast_spec.rb
@@ -43,6 +43,7 @@ describe '/api/v1/forecast endpoint' do
     expect(daily.first[:day]).to eq('Saturday')
     expect(daily.first[:icon]).to eq('clear-day')
     expect(daily.first[:precip_probability]).to eq('8%')
+    expect(daily.first[:precip_type]).to eq('snow')
     expect(daily.first[:temp_high]).to eq(51.75)
     expect(daily.first[:temp_low]).to eq(27.56)
   end


### PR DESCRIPTION
### Example
```
"daily": {
                "data": [
                    {
                        "day": "Sunday",
                        "icon": "partly-cloudy-day",
                        "precip_probability": "6%",
                        "precip_type": "rain",
                        "temp_high": 57.92,
                        "temp_low": 28.87
                    }
```