### PR TITLE
Time mock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,11 +31,9 @@ group :development, :test do
 end
 
 group :test do
-  gem 'mocha'
   gem 'rspec-rails'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
-  gem 'timecop'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,14 +82,11 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metaclass (0.0.4)
     method_source (0.9.2)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
-    mocha (1.9.0)
-      metaclass (~> 0.0.1)
     msgpack (1.3.1)
     multipart-post (2.1.1)
     nio4r (2.5.2)
@@ -162,7 +159,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -171,7 +168,6 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
-    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     webmock (3.7.6)
@@ -193,7 +189,6 @@ DEPENDENCIES
   fast_jsonapi
   figaro
   listen (>= 3.0.5, < 3.2)
-  mocha
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.11)
@@ -203,7 +198,6 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
-  timecop
   tzinfo-data
   webmock
 

--- a/spec/mock_helper.rb
+++ b/spec/mock_helper.rb
@@ -35,8 +35,9 @@ def stub_denver_to_pueblo_directions
 end
 
 def stub_pueblo_future_forecast
-  service = ForecastService.new('39.7392358,-104.990251', 1573009319)
-  json = File.open('./spec/fixtures/forecast_future_pueblo.json')
-  stub_request(:get, service.request_path)
-    .to_return(status: 200, body: json)
+  json = File.read('./spec/fixtures/forecast_future_pueblo.json')
+  data = JSON.parse(json, symbolize_names: true)
+  allow_any_instance_of(ForecastService)
+    .to receive(:get_forecast)
+    .and_return(data)
 end

--- a/spec/models/background_image_spec.rb
+++ b/spec/models/background_image_spec.rb
@@ -18,7 +18,7 @@ describe BackgroundImage do
 
   describe 'instance methods' do
     it '#random_url' do
-      expect(@bg_img.random_url).to include('https://images.unsplash.com/photo')
+      expect(@bg_img.random_url).to include('https://images.unsplash.com/')
     end
   end
 end

--- a/spec/requests/api/v1/road_trip_spec.rb
+++ b/spec/requests/api/v1/road_trip_spec.rb
@@ -1,12 +1,11 @@
 require 'mock_helper'
 
 describe 'POST /api/v1/road_trip', type: :request do
-  WebMock.allow_net_connect!
+
   before :each do
     stub_denver_to_pueblo_directions
     stub_pueblo_future_forecast
 
-    # Timecop.freeze(Time.at 1573009319)
     @user = User.create(email: 'bob@ross.com', password: 'tree', password_confirmation: 'tree' )
 
     @body = {
@@ -22,8 +21,6 @@ describe 'POST /api/v1/road_trip', type: :request do
   end
 
   it 'returns a forecast for estimated arrival time in destination city' do
-    # frozen_time = Time.at 1573009319
-    # Time.stubs(:now).returns(frozen_time)
     post '/api/v1/road_trip', params: @body, headers: @headers
 
     expect(response.status).to eq(200)
@@ -35,9 +32,9 @@ describe 'POST /api/v1/road_trip', type: :request do
     expect(data[:data][:type]).to eq('road_trip')
 
     attributes = data[:data][:attributes]
-    expect(attributes[:temperature]).to eq(40)
-    expect(attributes[:summary]).to eq('Clearly')
-    expect(attributes[:approx_travel_time]).to eq('5555')
+    expect(attributes[:temperature]).to eq(41.31)
+    expect(attributes[:summary]).to eq('Clear')
+    expect(attributes[:approx_travel_time]).to eq('1 hour 48 mins')
   end
 
   it 'returns status 401 with error message if key invalid' do

--- a/spec/services/forecast_service_spec.rb
+++ b/spec/services/forecast_service_spec.rb
@@ -18,4 +18,16 @@ describe ForecastService do
     expect(data).to have_key(:hourly)
     expect(data).to have_key(:offset)
   end
+
+  it 'can initialize with added travel time to change the request_path' do
+    time = Time.at(1573000000)
+    allow(Time).to receive(:now).and_return(time)
+
+    travel_time = 5678
+    future_time = Time.now.to_i + travel_time
+
+    service = ForecastService.new('38, -104', travel_time)
+
+    expect(service.request_path).to include(future_time.to_s)
+  end
 end


### PR DESCRIPTION
- Successfully mock road trip request spec by stubbing ForecastService#get_forecast with specific JSON output. 
- Remove unnecessary testing gems.
- Add test for future forecast in forecast service spec.