### PR TITLE
Add error handling for bad requests

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,8 @@
+class ErrorsController < ApplicationController
+  def index
+    render json: {
+      status: 400,
+      errors: 'Path to endpoint does not exist or has syntax error'
+    }, status: 400
+  end
+end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,7 +2,7 @@ class ErrorsController < ApplicationController
   def index
     render json: {
       status: 400,
-      errors: 'Path to endpoint does not exist or has syntax error'
+      errors: 'Endpoint does not exist or has syntax error'
     }, status: 400
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,6 @@ Rails.application.routes.draw do
       post '/road_trip', to: 'road_trips#create'
     end
   end
+
+  match "*path", to: "errors#index", via: :all
 end

--- a/spec/requests/api/v1/bad_request_spec.rb
+++ b/spec/requests/api/v1/bad_request_spec.rb
@@ -8,6 +8,6 @@ describe 'A request is sent to non-existant endpoint/typo' do
 
     expect(response.status).to eq(400)
     expect(data['status']).to eq(400)
-    expect(data['errors']).to eq('Path to endpoint does not exist or has syntax error')
+    expect(data['errors']).to eq('Endpoint does not exist or has syntax error')
   end
 end

--- a/spec/requests/api/v1/bad_request_spec.rb
+++ b/spec/requests/api/v1/bad_request_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe 'A request is sent to non-existant endpoint/typo' do
+  it 'returns 400 response with error message' do
+    get '/api/v1/this-is-not-an-endpoint'
+
+    data = JSON.parse(response.body)
+
+    expect(response.status).to eq(400)
+    expect(data['status']).to eq(400)
+    expect(data['errors']).to eq('Path to endpoint does not exist or has syntax error')
+  end
+end


### PR DESCRIPTION
If a request is sent to any non-existant endpoint, 400 response with the following body is returned:
```
{
    "status": 400,
    "errors": "Endpoint does not exist or has syntax error"
}
```