### PR TITLE
Refactor decorator

### DIFF
--- a/app/decorators/forecast_decorator.rb
+++ b/app/decorators/forecast_decorator.rb
@@ -21,14 +21,7 @@ class ForecastDecorator < SimpleDelegator
   def daily_forecast
     next_5_days = daily[:data].first(5)
     next_5_days.map do |day|
-      ForecastDaily.new(
-        day: time_abbr(day[:time], :day),
-        icon: day[:icon],
-        precip_probability: convert_pct(day[:precipProbability]),
-        precip_type: day[:precipType],
-        temp_high: day[:temperatureHigh],
-        temp_low: day[:temperatureLow]
-      )
+      ForecastDaily.new(self, day)
     end
   end
 

--- a/app/decorators/forecast_decorator.rb
+++ b/app/decorators/forecast_decorator.rb
@@ -51,6 +51,8 @@ class ForecastDecorator < SimpleDelegator
     end
   end
 
+  private
+
   def time_obj
     @time_obj ||= Time.at current_time
   end

--- a/app/decorators/forecast_decorator.rb
+++ b/app/decorators/forecast_decorator.rb
@@ -43,8 +43,6 @@ class ForecastDecorator < SimpleDelegator
     midnight_forecast[:summary]
   end
 
-  private
-
   def time
     time_obj.strftime("%l:%M %p").strip
   end
@@ -52,6 +50,8 @@ class ForecastDecorator < SimpleDelegator
   def date
     time_obj.strftime("%m/%d")
   end
+
+  private
 
   def convert_pct(pct)
     (pct * 100).to_i.to_s + '%'

--- a/app/decorators/forecast_decorator.rb
+++ b/app/decorators/forecast_decorator.rb
@@ -14,11 +14,7 @@ class ForecastDecorator < SimpleDelegator
   def hourly_forecast
     next_8_hours = hourly[:data].first(8)
     next_8_hours.map do |hour|
-      ForecastHourly.new(
-        time: time_abbr(hour[:time], :hour),
-        icon: hour[:icon],
-        temperature: hour[:temperature]
-      )
+      ForecastHourly.new(self, hour)
     end
   end
 
@@ -36,7 +32,6 @@ class ForecastDecorator < SimpleDelegator
     end
   end
 
-
   def summary_tonight
     time = get_midnight_timestamp
     midnight_forecast = hourly[:data].find { |t| t[:time] == time }
@@ -50,8 +45,6 @@ class ForecastDecorator < SimpleDelegator
   def date
     time_obj.strftime("%m/%d")
   end
-
-  private
 
   def convert_pct(pct)
     (pct * 100).to_i.to_s + '%'

--- a/app/decorators/forecast_decorator.rb
+++ b/app/decorators/forecast_decorator.rb
@@ -4,26 +4,11 @@ class ForecastDecorator < SimpleDelegator
   end
 
   def summary
-    ForecastSummary.new(
-      today: summary_today,
-      tonight: summary_tonight,
-      temp_high: temp_high,
-      temp_low: temp_low
-    )
+    ForecastSummary.new(self)
   end
 
   def current_forecast
-    ForecastCurrent.new(
-      time: time,
-      date: date,
-      summary: summary_current,
-      icon: icon,
-      temperature: temp_current,
-      feels_like: feels_like,
-      humidity: humidity,
-      visibility: visibility,
-      uv_index: uv_index
-    )
+    ForecastCurrent.new(self)
   end
 
   def hourly_forecast
@@ -51,13 +36,14 @@ class ForecastDecorator < SimpleDelegator
     end
   end
 
-  private
 
   def summary_tonight
     time = get_midnight_timestamp
     midnight_forecast = hourly[:data].find { |t| t[:time] == time }
     midnight_forecast[:summary]
   end
+
+  private
 
   def time
     time_obj.strftime("%l:%M %p").strip

--- a/app/decorators/geolocation_decorator.rb
+++ b/app/decorators/geolocation_decorator.rb
@@ -4,12 +4,6 @@ class GeolocationDecorator < SimpleDelegator
   end
 
   def location_info
-    LocationInfo.new(
-      city: city,
-      state: state,
-      country: country,
-      latitude: latitude,
-      longitude: longitude
-    )
+    LocationInfo.new(self)
   end
 end

--- a/app/models/forecast_current.rb
+++ b/app/models/forecast_current.rb
@@ -1,13 +1,13 @@
 class ForecastCurrent
-  def initialize(args)
-    @time = args[:time]
-    @date = args[:date]
-    @summary = args[:summary]
-    @icon = args[:icon]
-    @temperature = args[:temperature]
-    @feels_like = args[:feels_like]
-    @humidity = args[:humidity]
-    @visibility = args[:visibility]
-    @uv_index = args[:uv_index]
+  def initialize(obj)
+    @time = obj.time
+    @date = obj.date
+    @summary = obj.summary_current
+    @icon = obj.icon
+    @temperature = obj.temp_current
+    @feels_like = obj.feels_like
+    @humidity = obj.humidity
+    @visibility = obj.visibility
+    @uv_index = obj.uv_index
   end
 end

--- a/app/models/forecast_daily.rb
+++ b/app/models/forecast_daily.rb
@@ -1,10 +1,10 @@
 class ForecastDaily
-  def initialize(args)
-    @day = args[:day]
-    @icon = args[:icon]
-    @precip_probability = args[:precip_probability]
-    @precip_type = args[:precip_type]
-    @temp_high = args[:temp_high]
-    @temp_low = args[:temp_low]
+  def initialize(obj, day)
+    @day = obj.time_abbr(day[:time], :day)
+    @icon = day[:icon]
+    @precip_probability = obj.convert_pct(day[:precipProbability])
+    @precip_type = day[:precipType]
+    @temp_high = day[:temperatureHigh]
+    @temp_low = day[:temperatureLow]
   end
 end

--- a/app/models/forecast_hourly.rb
+++ b/app/models/forecast_hourly.rb
@@ -1,7 +1,7 @@
 class ForecastHourly
-  def initialize(args)
-    @time = args[:time]
-    @icon = args[:icon]
-    @temperature = args[:temperature]
+  def initialize(obj, hour)
+    @time = obj.time_abbr(hour[:time], :hour)
+    @icon = hour[:icon]
+    @temperature = hour[:temperature]
   end
 end

--- a/app/models/forecast_summary.rb
+++ b/app/models/forecast_summary.rb
@@ -1,8 +1,8 @@
 class ForecastSummary
-  def initialize(args)
-    @today = args[:today]
-    @tonight = args[:tonight]
-    @temp_high = args[:temp_high]
-    @temp_low = args[:temp_low]
+  def initialize(obj)
+    @today = obj.summary_today
+    @tonight = obj.summary_tonight
+    @temp_high = obj.temp_high
+    @temp_low = obj.temp_low
   end
 end

--- a/app/models/location_info.rb
+++ b/app/models/location_info.rb
@@ -1,9 +1,16 @@
 class LocationInfo
-  def initialize(args)
-    @city = args[:city]
-    @state = args[:state]
-    @country = args[:country]
-    @latitude = args[:latitude]
-    @longitude = args[:longitude]
+  def initialize(obj)
+    @city = obj.city
+    @state = obj.state
+    @country = obj.country
+    @latitude = obj.latitude
+    @longitude = obj.longitude
   end
 end
+  # 
+  #
+  # city: city,
+  # state: state,
+  # country: country,
+  # latitude: latitude,
+  # longitude: longitude

--- a/spec/models/forecast_current_spec.rb
+++ b/spec/models/forecast_current_spec.rb
@@ -2,18 +2,13 @@ require 'rails_helper'
 
 describe ForecastCurrent do
   it 'can initialize with keyword arguments' do
-    forecast =
-      ForecastCurrent.new(
-        time: 'time',
-        date: 'date',
-        summary: 'summary_current',
-        icon: 'icon',
-        temperature: 'temp_current',
-        feels_like: 'feels_like',
-        humidity: 'humidity',
-        visibility: 'visibility',
-        uv_index: 'uv_index'
-      )
+    stub_denver_forecast
+
+    service = ForecastService.new('39.7392358,-104.990251')
+    forecast = Forecast.new(service.get_forecast)
+    decorator = ForecastDecorator.new(forecast)
+    forecast = ForecastCurrent.new(decorator)
+    
     expect(forecast).to be_an_instance_of(ForecastCurrent)
   end
 end

--- a/spec/models/forecast_current_spec.rb
+++ b/spec/models/forecast_current_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 describe ForecastCurrent do
-  it 'can initialize with keyword arguments' do
+  it 'can initialize with a forecast decorator object' do
     stub_denver_forecast
 
     service = ForecastService.new('39.7392358,-104.990251')
     forecast = Forecast.new(service.get_forecast)
     decorator = ForecastDecorator.new(forecast)
     forecast = ForecastCurrent.new(decorator)
-    
+
     expect(forecast).to be_an_instance_of(ForecastCurrent)
   end
 end

--- a/spec/models/forecast_daily_spec.rb
+++ b/spec/models/forecast_daily_spec.rb
@@ -2,15 +2,14 @@ require 'rails_helper'
 
 describe ForecastDaily do
   it 'can initialize with keyword arguments' do
-    forecast =
-      ForecastDaily.new(
-        day: 'day',
-        icon: 'icon',
-        precip_probability: 'pct',
-        precip_type: 'type',
-        temp_high: 'high',
-        temp_low: 'low'
-      )
+    stub_denver_forecast
+
+    service = ForecastService.new('39.7392358,-104.990251')
+    forecast = Forecast.new(service.get_forecast)
+    decorator = ForecastDecorator.new(forecast)
+    day = decorator.daily[:data].first
+    forecast = ForecastDaily.new(decorator, day)
+    
     expect(forecast).to be_an_instance_of(ForecastDaily)
   end
 end

--- a/spec/models/forecast_daily_spec.rb
+++ b/spec/models/forecast_daily_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 describe ForecastDaily do
-  it 'can initialize with keyword arguments' do
+  it 'can initialize with decorator object and day hash' do
     stub_denver_forecast
 
     service = ForecastService.new('39.7392358,-104.990251')
     forecast = Forecast.new(service.get_forecast)
     decorator = ForecastDecorator.new(forecast)
     day = decorator.daily[:data].first
+
     forecast = ForecastDaily.new(decorator, day)
-    
     expect(forecast).to be_an_instance_of(ForecastDaily)
   end
 end

--- a/spec/models/forecast_hourly_spec.rb
+++ b/spec/models/forecast_hourly_spec.rb
@@ -2,12 +2,14 @@ require 'rails_helper'
 
 describe ForecastHourly do
   it 'can initialize with keyword arguments' do
-    forecast =
-      ForecastHourly.new(
-        time: 'time',
-        icon: 'icon',
-        temperature: 'temp'
-      )
+    stub_denver_forecast
+
+    service = ForecastService.new('39.7392358,-104.990251')
+    forecast = Forecast.new(service.get_forecast)
+    decorator = ForecastDecorator.new(forecast)
+    hour = decorator.hourly[:data].first
+
+    forecast = ForecastHourly.new(decorator, hour)
     expect(forecast).to be_an_instance_of(ForecastHourly)
   end
 end

--- a/spec/models/forecast_hourly_spec.rb
+++ b/spec/models/forecast_hourly_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe ForecastHourly do
-  it 'can initialize with keyword arguments' do
+  it 'can initialize with decorator object and hour hash' do
     stub_denver_forecast
 
     service = ForecastService.new('39.7392358,-104.990251')

--- a/spec/models/forecast_summary_spec.rb
+++ b/spec/models/forecast_summary_spec.rb
@@ -8,6 +8,7 @@ describe ForecastSummary do
     forecast = Forecast.new(service.get_forecast)
     decorator = ForecastDecorator.new(forecast)
     summary = ForecastSummary.new(decorator)
+
     expect(summary).to be_an_instance_of(ForecastSummary)
   end
 end

--- a/spec/models/forecast_summary_spec.rb
+++ b/spec/models/forecast_summary_spec.rb
@@ -1,14 +1,13 @@
-require 'rails_helper'
+require 'mock_helper'
 
 describe ForecastSummary do
   it 'can initialize with keyword arguments' do
-    forecast =
-      ForecastSummary.new(
-        today: 'summary_today',
-        tonight: 'summary_tonight',
-        temp_high: 'temp_high',
-        temp_low: 'temp_low'
-      )
-    expect(forecast).to be_an_instance_of(ForecastSummary)
+    stub_denver_forecast
+
+    service = ForecastService.new('39.7392358,-104.990251')
+    forecast = Forecast.new(service.get_forecast)
+    decorator = ForecastDecorator.new(forecast)
+    summary = ForecastSummary.new(decorator)
+    expect(summary).to be_an_instance_of(ForecastSummary)
   end
 end

--- a/spec/models/forecast_summary_spec.rb
+++ b/spec/models/forecast_summary_spec.rb
@@ -1,7 +1,7 @@
 require 'mock_helper'
 
 describe ForecastSummary do
-  it 'can initialize with keyword arguments' do
+  it 'can initialize with a forecast decorator object' do
     stub_denver_forecast
 
     service = ForecastService.new('39.7392358,-104.990251')

--- a/spec/models/location_info_spec.rb
+++ b/spec/models/location_info_spec.rb
@@ -1,15 +1,13 @@
-require 'rails_helper'
+require 'mock_helper'
 
 describe LocationInfo do
-  it 'can initialize with keywords' do
-    location_info =
-      LocationInfo.new(
-        city: 'city',
-        state: 'state',
-        country: 'country',
-        latitude: 'latitude',
-        longitude: 'longitude'
-      )
+  it 'can initialize with GeolocationDecorator object' do
+    stub_denver_location
+    service = GeocodeService.new('denver,co')
+    location = Geolocation.new(service.get_location)
+    decorator = GeolocationDecorator.new(location)
+    
+    location_info = LocationInfo.new(decorator)
     expect(location_info).to be_an_instance_of(LocationInfo)
   end
 end


### PR DESCRIPTION
- The forecast decorator used to use hardcoded keyword arguments to initialize helper POROs for serialization. Now it passes self as an argument.
- Similar changes to geolocation decorator
- Refactor tests for those POROs to reflect the changes in the ForecastDecorator